### PR TITLE
fixed issue with order clause getting duplicate params

### DIFF
--- a/lib/fake_arel/extensions.rb
+++ b/lib/fake_arel/extensions.rb
@@ -52,7 +52,9 @@ module ActiveRecord
               ret[:joins] = merge_joins((ret[:joins] || []), (local_scope.proxy_options[:joins] || []))
             end
           end
-          ret[:order] = [local_scope.proxy_options[:order], ret[:order]].select{|o| !o.blank?}.join(',') if ret[:order] || local_scope.proxy_options[:order]
+          local_proxy_order_options = local_scope.proxy_options[:order].split(',') unless local_scope.proxy_options[:order].nil?
+          ret_order_options = ret[:order].split(',') unless ret[:order].nil?
+          ret[:order] = [local_proxy_order_options, ret_order_options].flatten.uniq.select{|o| !o.blank?}.join(',') if ret[:order] || local_scope.proxy_options[:order]
           local_scope = local_scope.proxy_scope
         end
         ret

--- a/spec/fake_arel_spec.rb
+++ b/spec/fake_arel_spec.rb
@@ -48,6 +48,12 @@ describe "Fake Arel" do
     sql.should =~ /"topic_id" = 4/
     sql.should =~ /ORDER BY id desc/i
   end
+
+  it "should generate same sql always" do
+    first_sql = Topic.first_four_sorted_by_date.to_sql
+    second_sql = Topic.first_four_sorted_by_date.to_sql
+    first_sql.should == second_sql
+  end
   it "should not dublication conditions" do
     sql = Topic.select('content').joins(:replies).limit(1).order('id desc').where(:author_id => 1).to_sql
     sql.should_not =~ /"author_id" = 1.+"author_id" = 1/

--- a/spec/fixtures/topic.rb
+++ b/spec/fixtures/topic.rb
@@ -15,4 +15,5 @@ class Topic < ActiveRecord::Base
   named_scope :join_replies_by_string_and_author, join_replies_by_string.joins(:author)
   named_scope :join_replies_by_string_and_author_lambda, join_replies_by_string.joins(:author)
   named_scope :select_only_id, select('id as super_duper_id').includes(:replies)
+  named_scope :first_four_sorted_by_date, order('id ASC').order('created_at DESC').limit(4)
 end


### PR DESCRIPTION
A while back we had noticed that if I have an order clause in the named scope, the sql query keeps getting duplicate column params for the clause every time it is invoked. Added a quick fix -- please review and incorporate.

cheers!
-p  
