### PR TITLE
Bugfix for 'or' scope

### DIFF
--- a/lib/fake_arel/rails_3_finders.rb
+++ b/lib/fake_arel/rails_3_finders.rb
@@ -41,9 +41,10 @@ module Rails3Finders
         # for some reason, flatten is actually executing the scope
         scopes = scopes[0] if scopes.size == 1
         scopes.each do |s|
+          scope = s.proxy_scope
           s = s.proxy_options
           begin
-            where << merge_conditions(s[:conditions])
+            where << scope.merge_conditions(s[:conditions])
           rescue NoMethodError
             # I am ActiveRecord::Base. Only my subclasses define merge_conditions:
             where << subclasses.first.merge_conditions(s[:conditions])

--- a/spec/fake_arel_spec.rb
+++ b/spec/fake_arel_spec.rb
@@ -206,6 +206,12 @@ describe "Fake Arel" do
     Reply.or(q1,q2).all.map(&:id).should == [2]
   end
 
+  it 'should be able to combine with "or" a different class' do
+    q1 = Author.where(:id => 0)
+    q2 = Author.where(:id => 1)
+    Author.or(q1,q2).all.map(&:id).should == [1]
+  end
+
   it "should use select like rails 3 uses select" do
     lambda { Reply.all.select {|r| r.id == 1 }}.should_not raise_error
     Reply.all.select {|r| r.id == 1 }.size.should == 1


### PR DESCRIPTION
The 'or' scope did not work properly as it was executing the requests on the ActiveRecord::Base class and then falling back to the first subclass. (so it essentially only worked for one class). I think that using the proper scope for the conditions makes the rescue block useless, but I'm not sure so I've left it as it is.
