### PR TITLE
Fix specs. 

### DIFF
--- a/lib/fake_arel/rails_3_finders.rb
+++ b/lib/fake_arel/rails_3_finders.rb
@@ -66,11 +66,11 @@ module Rails3Finders
         # include is renamed to includes in Rails 3
         includes = options.delete(:includes)
         options << :include if includes
-  
+
         new_options = (scope(:find) || {}).reject { |k, v| options.include?(k) }
         with_exclusive_scope(:find => new_options) { scoped }
       end
-  
+
       # returns a new scope, with just the order replaced
       # does *not* support extended scopes
       def self.reorder(*order)
@@ -78,7 +78,7 @@ module Rails3Finders
         new_options[:order] = order.flatten.join(',')
         with_exclusive_scope(:find =>new_options) { scoped }
       end
-    
+
       def self.pluck(column)
         new_options = (scope(:find) || {}).dup
         new_options[:select] = "#{quoted_table_name}.#{column}"

--- a/lib/fake_arel/with_scope_replacement.rb
+++ b/lib/fake_arel/with_scope_replacement.rb
@@ -21,7 +21,7 @@ module WithScopeReplacement
 
           return sanitize_sql(sql)
         end
-        
+
         def with_scope(method_scoping = {}, action = :merge, &block)
           method_scoping = {:find => method_scoping.proxy_options} if method_scoping.class == ActiveRecord::NamedScope::Scope
           method_scoping = method_scoping.method_scoping if method_scoping.respond_to?(:method_scoping)

--- a/spec/fake_arel_spec.rb
+++ b/spec/fake_arel_spec.rb
@@ -329,10 +329,9 @@ end
 
 describe "scoped" do
   it "uses the scoped method" do
-    Topic.where(id: [2, 3]).scoping do
-      Topic.where(id: 2).scoping do
-        Topic.all.map(&:id).should == [2]
-      end
+    Topic.where(id: 2).scoped do
+      Topic.all.size.should == 1
+      Topic.all.map(&:id).should == [2]
     end
   end
 end

--- a/spec/fixtures/replies.yml
+++ b/spec/fixtures/replies.yml
@@ -3,13 +3,13 @@ witty_retort:
   topic_id: 1
   content: Birdman is better!
   created_at: <%= 6.hours.ago.utc.iso8601 %>
-  
+
 another:
   id: 2
   topic_id: 2
   content: Nuh uh!
   created_at: <%= 1.hour.ago.utc.iso8601 %>
-  
+
 spam:
   id: 3
   topic_id: 1
@@ -20,7 +20,7 @@ decisive:
   id: 4
   topic_id: 4
   content: "I'm getting to the bottom of this"
-  created_at: <%= 30.minutes.ago.localtime.iso8601 %>
+  created_at: <%= 30.minutes.ago.utc.iso8601 %>
 
 brave:
   id: 5


### PR DESCRIPTION
Many of them were failing because of inconsistent created_at attributes in the replies fixtures. 

I've fixed the `scoped` spec too.  It was assuming that `scoping` nesting using the same key (`id`) is possible in fake_arel when it's not. Due to the `deep_merge` done in `with_scope` (cf. [with_scope_replacement.rb](https://github.com/gammons/fake_arel/blob/master/lib/fake_arel/with_scope_replacement.rb#L51)) the innermost `scoped` was getting overwritten and returning 2 records instead of the expect one. AR do manage this correctly from 3.0.x 

This is just the first of a series of PRs to get specs working again. 