### PR TITLE
Fix Scope#select method to provide block-style and Rails 3 style use.

### DIFF
--- a/lib/fake_arel/extensions.rb
+++ b/lib/fake_arel/extensions.rb
@@ -30,8 +30,15 @@ module ActiveRecord
     end
 
     class Scope
-      undef select
       undef from
+
+      def select(value = Proc.new)
+        if block_given?
+          all.select {|*block_args| value.call(*block_args) }
+        else
+          self.scoped(:select => Array.wrap(value).join(','))
+        end
+      end
 
       alias initialize_without_arel initialize
       def initialize(proxy_scope, options = {}, &block)

--- a/spec/fake_arel_spec.rb
+++ b/spec/fake_arel_spec.rb
@@ -227,11 +227,29 @@ describe "Fake Arel" do
     Author.or(q1,q2).all.map(&:id).should == [1]
   end
 
-  it "should use select like rails 3 uses select" do
+  it "should respect Array#select and Scope#select traditional block use" do
     lambda { Reply.all.select {|r| r.id == 1 }}.should_not raise_error
-    Reply.all.select {|r| r.id == 1 }.size.should == 1
-    Reply.all.select {|r| r.id == 1 }.first.id.should == 1
+    replies = Reply.all.select {|r| r.id == 1 }
+    replies.size.should == 1
+    replies.first.id.should == 1
+
+    lambda { Topic.find(4).replies.recent.select {|r| r.id == 5 }}.should_not raise_error
+    replies = Topic.find(4).replies.recent.select {|r| r.id == 5 }
+    replies.size.should == 1
+    replies.first.id.should == 5
+  end
+
+  it "should provide Model#select and Scope#select for Rails 3 use" do
+    lambda { Reply.select(:id).first}.should_not raise_error
     lambda { Reply.select(:id).first.content }.should raise_error(ActiveRecord::MissingAttributeError)
+    Reply.select(:id).first.id.should == 1
+    Reply.select(:id).first.attributes.keys.should == ["id"]
+
+
+    lambda { Topic.find(4).replies.recent.select(:id).first}.should_not raise_error
+    lambda { Topic.find(4).replies.recent.select(:id).first.content }.should raise_error(ActiveRecord::MissingAttributeError)
+    Topic.find(4).replies.recent.select(:id).first.id.should == 5
+    Topic.find(4).replies.recent.select(:id).first.attributes.keys.should == ["id"]
   end
 
   it "should respond to batch_find" do


### PR DESCRIPTION
Previously (cf. a5cd82bbb1208c4dc6fe6fdd0feb0f7dad92c97c) fake_arel has been fixed to respect the regular `Array#select` implementation that receives a block, providing the option to write code like `Reply.all.select {|r| r.id == 1 }`.

However, trying to use `Scope#select` in the same way will generate a ` wrong number of arguments (0 for 1..4)` error because of the way `select` has been `undef` in the scopes.

This PR fix this problem.